### PR TITLE
Support for get color from MaterialShapeDrawable instead of ColorDraw…

### DIFF
--- a/drawerbehavior/build.gradle
+++ b/drawerbehavior/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
 //    implementation 'com.github.rjsvieira:morphos:1.0.0'
 

--- a/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
+++ b/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
@@ -22,6 +22,7 @@ import androidx.core.view.ViewCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 
 import com.google.android.material.navigation.NavigationView;
+import com.google.android.material.shape.MaterialShapeDrawable;
 
 import java.util.HashMap;
 
@@ -312,8 +313,17 @@ public class AdvanceDrawerLayout extends DrawerLayout {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                             setSystemUiVisibility(ColorUtils.calculateContrast(Color.WHITE, bgColor) < contrastThreshold && slideOffset > 0.4 ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
                         }
-                    }
+                    } else if (drawerView.getBackground() instanceof MaterialShapeDrawable
+                                && ((MaterialShapeDrawable) drawerView.getBackground()).getFillColor() != null) {
+                        int color = ColorUtils.setAlphaComponent(statusBarColor, (int) (255 - 255 * slideOffset));
+                        window.setStatusBarColor(color);
 
+                        int bgColor = ((MaterialShapeDrawable) drawerView.getBackground()).getFillColor().getDefaultColor();
+                        window.getDecorView().setBackgroundColor(bgColor);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                            setSystemUiVisibility(ColorUtils.calculateContrast(Color.WHITE, bgColor) < contrastThreshold && slideOffset > 0.4 ? View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR : 0);
+                        }
+                    }
 
                 }
 


### PR DESCRIPTION
…able

ColorDrawable is not use anymore as background since MaterialComponent 1.1.0

The changes are following your conditional pattern, but the code could be reduce. 
Could you review the change and create a new version for maven? I wish I could use the library from the repositories