### PR TITLE
Support for set background of CardView in advance drawer layout

### DIFF
--- a/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
+++ b/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
@@ -7,7 +7,6 @@ import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -42,7 +41,7 @@ public class AdvanceDrawerLayout extends DrawerLayout {
     private int statusBarColor;
     private boolean defaultFitsSystemWindows;
     private float contrastThreshold = 3;
-    private Drawable cardBackground = null;
+    private int cardColor;
 
     public AdvanceDrawerLayout(Context context) {
         super(context);
@@ -65,7 +64,7 @@ public class AdvanceDrawerLayout extends DrawerLayout {
 
     private void init(Context context, AttributeSet attrs, int defStyle) {
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.advDrawerLayout);
-        cardBackground = a.getDrawable(R.styleable.advDrawerLayout_adl_cardBackground);
+        cardColor = a.getColor(R.styleable.advDrawerLayout_adl_cardBackgroundColor, Color.WHITE);
         a.recycle();
         defaultDrawerElevation = getDrawerElevation();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
@@ -151,12 +150,7 @@ public class AdvanceDrawerLayout extends DrawerLayout {
             cardView.setRadius(0);
             cardView.addView(child);
             cardView.setCardElevation(0);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                cardView.setBackground(cardBackground);
-            }
-            else{
-                cardView.setBackgroundDrawable(cardBackground);
-            }
+            cardView.setCardBackgroundColor(cardColor);
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                 cardView.setContentPadding(-6, -9, -6, -9);
             }

--- a/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
+++ b/drawerbehavior/src/main/java/com/infideap/drawerbehavior/AdvanceDrawerLayout.java
@@ -4,8 +4,10 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.res.Configuration;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -40,6 +42,7 @@ public class AdvanceDrawerLayout extends DrawerLayout {
     private int statusBarColor;
     private boolean defaultFitsSystemWindows;
     private float contrastThreshold = 3;
+    private Drawable cardBackground = null;
 
     public AdvanceDrawerLayout(Context context) {
         super(context);
@@ -61,6 +64,9 @@ public class AdvanceDrawerLayout extends DrawerLayout {
 
 
     private void init(Context context, AttributeSet attrs, int defStyle) {
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.advDrawerLayout);
+        cardBackground = a.getDrawable(R.styleable.advDrawerLayout_adl_cardBackground);
+        a.recycle();
         defaultDrawerElevation = getDrawerElevation();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             defaultFitsSystemWindows = getFitsSystemWindows();
@@ -145,7 +151,13 @@ public class AdvanceDrawerLayout extends DrawerLayout {
             cardView.setRadius(0);
             cardView.addView(child);
             cardView.setCardElevation(0);
-            if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                cardView.setBackground(cardBackground);
+            }
+            else{
+                cardView.setBackgroundDrawable(cardBackground);
+            }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                 cardView.setContentPadding(-6, -9, -6, -9);
             }
             frameLayout.addView(cardView);

--- a/drawerbehavior/src/main/res/values/attrs.xml
+++ b/drawerbehavior/src/main/res/values/attrs.xml
@@ -6,6 +6,6 @@
         <attr name="adl_viewScrimColor" format="color" />
         <attr name="adl_viewElevation" format="dimension" />
         <attr name="adl_drawerElevation" format="dimension" />
-        <attr name="adl_cardBackground" format="reference|color" />
+        <attr name="adl_cardBackgroundColor" format="reference|color" />
     </declare-styleable>
 </resources>

--- a/drawerbehavior/src/main/res/values/attrs.xml
+++ b/drawerbehavior/src/main/res/values/attrs.xml
@@ -6,5 +6,6 @@
         <attr name="adl_viewScrimColor" format="color" />
         <attr name="adl_viewElevation" format="dimension" />
         <attr name="adl_drawerElevation" format="dimension" />
+        <attr name="adl_cardBackground" format="reference|color" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
I wanted to set my main content view translucent when opening the drawer but by default it had a white background and was not able to change it.
Upon further inspection I saw that Views that are not instanceOf NavigationView are added into a CardView.

What I did was to create a cardBackground variable and the attribute "adl_cardBackground" to change the default background.

I thought that it will be a nice feature to have so I decided to make a pull request.